### PR TITLE
러닝 컴포넌트 거리 oneOnOne 버그

### DIFF
--- a/screen/Running/RunningScreen.js
+++ b/screen/Running/RunningScreen.js
@@ -32,7 +32,9 @@ const RunningScreen = ({ navigation }) => {
   );
 
   const [userDistance, setUserDistance] = useState(0);
-  const [opponentDistance, setOpponentDistance] = useState(-200);
+  const [opponentDistance, setOpponentDistance] = useState(
+    role === 'zombie' ? 200 : -200,
+  );
   const [hasGameStarted, setHasGameStarted] = useState(false);
   const [isWinner, setIsWinner] = useState(false);
   const [hasGameFinished, setHasGameFinished] = useState(false);
@@ -56,7 +58,7 @@ const RunningScreen = ({ navigation }) => {
   );
 
   const speedMeterPerSecond = Math.ceil(conversionRate * speed);
-  const distanceGap = Math.ceil(userDistance - opponentDistance);
+  const distanceGap = Math.ceil(Math.abs(userDistance - opponentDistance));
 
   const startRunning = async () => {
     setHasGameStarted(true);
@@ -120,10 +122,13 @@ const RunningScreen = ({ navigation }) => {
   const handleFinishGame = (remainingTime) => {
     if (remainingTime === 0 && role === 'human') {
       setIsWinner(true);
-    } else {
-      survivalTime.current -= remainingTime;
     }
 
+    if (remainingTime && role === 'zombie') {
+      setIsWinner(true);
+    }
+
+    survivalTime.current -= remainingTime;
     setHasGameFinished(true);
   };
 


### PR DESCRIPTION
# 러닝 컴포넌트 거리 oneOnOne 버그

## 노션 칸반 링크

- [버그수정](https://www.notion.so/vanillacoding/a7063509a6a24f149269794cc175e502)

## 구현사항

- Running 컴포넌트 oneOnOne의 승자 관련 로직 및 거리 계산시에 버그를 수정했습니다.

## 테스트 방법

- 에뮬레이터와 실제 안드로이드 기기를 활용하여 체크 했습니다.

## 보고 사항

- 현재 oneOnOne 관련 게임 시작시 로직에 버그가 있어서 결과 부분 처리 까지는 완벽하게 체크하지 못했습니다.
