### PR TITLE
러닝 컴포넌트 거리 계산 로직 관련 재수정

### DIFF
--- a/screen/Running/RunningScreen.js
+++ b/screen/Running/RunningScreen.js
@@ -205,7 +205,7 @@ const RunningScreen = ({ navigation }) => {
         userId,
         locationHistory: gameController.locationRecord,
         isWinner,
-        distance: kilometerDistance,
+        distance: kilometerDistance.toFixed(3),
         time: survivalTime.current,
         speed: kilometerPerHour.toFixed(1),
         role,

--- a/screen/Running/RunningScreen.js
+++ b/screen/Running/RunningScreen.js
@@ -205,7 +205,7 @@ const RunningScreen = ({ navigation }) => {
         userId,
         locationHistory: gameController.locationRecord,
         isWinner,
-        distance: kilometerDistance.toFixed(3),
+        distance: kilometerDistance.toFixed(1),
         time: survivalTime.current,
         speed: kilometerPerHour.toFixed(1),
         role,

--- a/screen/Running/RunningScreen.js
+++ b/screen/Running/RunningScreen.js
@@ -58,7 +58,6 @@ const RunningScreen = ({ navigation }) => {
   );
 
   const speedMeterPerSecond = Math.ceil(conversionRate * speed);
-
   const calculateDistance = () => {
     if (role === 'human') {
       return Math.ceil(userDistance - opponentDistance);

--- a/screen/Running/RunningScreen.js
+++ b/screen/Running/RunningScreen.js
@@ -58,7 +58,14 @@ const RunningScreen = ({ navigation }) => {
   );
 
   const speedMeterPerSecond = Math.ceil(conversionRate * speed);
-  const distanceGap = Math.ceil(Math.abs(userDistance - opponentDistance));
+
+  const calculateDistance = () => {
+    if (role === 'human') {
+      return Math.ceil(userDistance - opponentDistance);
+    }
+
+    return Math.ceil(opponentDistance - userDistance);
+  };
 
   const startRunning = async () => {
     setHasGameStarted(true);
@@ -249,7 +256,7 @@ const RunningScreen = ({ navigation }) => {
       <GameView
         role={role}
         mode={mode}
-        distanceGap={distanceGap}
+        distanceGap={calculateDistance()}
         hasStarted={hasGameStarted}
         gameController={gameController}
         onFinish={handleFinishDistanceResult}


### PR DESCRIPTION
# 러닝 컴포넌트 거리 계산 로직 관련 재수정

## 노션 칸반 링크

- [버그 수정](https://www.notion.so/vanillacoding/a7063509a6a24f149269794cc175e502)

## 구현사항

- 러닝 컴포넌트 거리 계산 관련 로직을 재수정했습니다. 
- 데이터 처리의 용이성을 위해 toFixed 처리를 추가 했습니다.

## 테스트 방법
-  안드로이드 에뮬레이터 활용 및 안드로이드 기기 활용
