### PR TITLE
러닝 컴포넌트 버그 수정 및 Main Page  컴포넌트 테스트 케이스 추가

### DIFF
--- a/common/utils/testStore.js
+++ b/common/utils/testStore.js
@@ -1,0 +1,21 @@
+import { createStore, combineReducers } from '@reduxjs/toolkit';
+
+import gameReducer from '../../store/gameSlice';
+import playerReducer from '../../store/playerSlice';
+import roomReducer from '../../store/roomSlice';
+import uiReducer from '../../store/uiSlice';
+import userReducer from '../../store/userSlice';
+
+export default function createTestStore() {
+  const store = createStore(
+    combineReducers({
+      user: userReducer,
+      game: gameReducer,
+      room: roomReducer,
+      player: playerReducer,
+      ui: uiReducer,
+    }),
+  );
+
+  return store;
+}

--- a/screen/Main/MainScree.test.js
+++ b/screen/Main/MainScree.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Provider } from 'react-redux';
+
+import createTestStore from '../../common/utils/testStore';
+import MainScreen from './MainScreen';
+
+const navigation = {
+  foo: jest.fn(),
+};
+let store;
+
+describe('랜더링 테스트', () => {
+  beforeEach(() => {
+    store = createTestStore();
+  });
+
+  it('프롭스를 넘겨 받을 시에 스냅샷과 일치하게 랜더 되야한다.', () => {
+    const tree = renderer
+      .create(
+        <Provider store={store}>
+          <MainScreen navigation={navigation} />
+        </Provider>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('랜더 시에 형성되는 트리는 두 개의 자식 만을 가져야 한다.', () => {
+    const tree = renderer
+      .create(
+        <Provider store={store}>
+          <MainScreen navigation={navigation} />
+        </Provider>,
+      )
+      .toJSON();
+    expect(tree.children.length).toBe(2);
+  });
+});

--- a/screen/OneOnOne/OneOnOneScreen.js
+++ b/screen/OneOnOne/OneOnOneScreen.js
@@ -68,7 +68,7 @@ const OneOnOneScreen = ({ navigation }) => {
   const handlePressStartButton = async () => {
     const gameId = await dispatch(
       createGameRecord({ mode: currentRoom.mode, userId, role }),
-    );
+    ).unwrap();
     emitGameStart(gameId);
     navigation.navigate('Running');
   };

--- a/screen/Running/RunningScreen.js
+++ b/screen/Running/RunningScreen.js
@@ -144,6 +144,8 @@ const RunningScreen = ({ navigation }) => {
     if (survivorCount === 1) {
       setIsWinner(true);
     }
+
+    setHasGameFinished(true);
   };
 
   useEffect(() => {
@@ -205,6 +207,7 @@ const RunningScreen = ({ navigation }) => {
         userId,
         locationHistory: gameController.locationRecord,
         isWinner,
+        mode,
         distance: kilometerDistance.toFixed(1),
         time: survivalTime.current,
         speed: kilometerPerHour.toFixed(1),

--- a/screen/Running/RunningScreen.js
+++ b/screen/Running/RunningScreen.js
@@ -144,8 +144,6 @@ const RunningScreen = ({ navigation }) => {
     if (survivorCount === 1) {
       setIsWinner(true);
     }
-
-    setHasGameFinished(true);
   };
 
   useEffect(() => {

--- a/screen/Running/components/Header.js
+++ b/screen/Running/components/Header.js
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
 });
 
 Header.propTypes = {
-  speed: PropTypes.number.isRequired,
+  speed: PropTypes.number,
   time: PropTypes.number,
   mode: PropTypes.string.isRequired,
   hasStarted: PropTypes.bool.isRequired,
@@ -98,4 +98,5 @@ Header.propTypes = {
 
 Header.defaultProps = {
   time: '',
+  speed: '',
 };

--- a/store/gameSlice.js
+++ b/store/gameSlice.js
@@ -56,7 +56,7 @@ export const updateGameRecord = createAsyncThunk(
       isWinner,
       time: Number(time),
       speed: Number(speed),
-      distance,
+      distance: Number(distance),
       role,
       id: userId,
     };


### PR DESCRIPTION
# 러닝 컴포넌트 버그 수정 및 Main Page  컴포넌트 테스트 케이스 추가

## 노션 칸반 링크

- [버그 수정](https://www.notion.so/vanillacoding/a7063509a6a24f149269794cc175e502)
- [테스트 코드](https://www.notion.so/vanillacoding/b6aff4882cce4f9dbb4a651f7f2a02bd)
## 구현사항

- 러닝 컴포넌트 oneOnOne 모드에서 존재하던 버그를 수정 했습니다.
  - result 객체에 빠져있던 mode를 추가했습니다. 
  - thunk 액션에 unwrap을 추가했습니다.
- redux 사용 컴포넌트를 위해 테스트 스토어 생성 함수를 유틸 함수에 추가했습니다.
- 메인 컴포넌트에 대한 기본적인 테스트 코드를 작성했습니다.
## 테스트 방법

- 안드로이드 에뮬레이터와 안드로이드 기기를 동시에 사용해서 디버깅 하였습니다.
